### PR TITLE
Added a hook to draw over and even override the HUD

### DIFF
--- a/lua/autorun/cstrikemoneysystem.lua
+++ b/lua/autorun/cstrikemoneysystem.lua
@@ -18,6 +18,7 @@ if CLIENT then
 	} )
 	
 	hook.Add( "HUDPaint", "CStrike_MoneyHUD", function()
+		if hook.Run('CStrike_MoneyHUD') then return end
 		local ply = LocalPlayer()
 		if IsValid(ply) and ply:Alive() then
 			if GAMEMODE_NAME == "zombiesurvival" then


### PR DESCRIPTION
Adding a hook.Run here allows developers to override the default HUD element without having to compromise the original HUDPaint hook.

Alternatively, we can replace `hook.Run("CStrike_Money")` with `hook.Run("HUDShouldDraw", "CStrike_Money") == false` if we want to use the HUDShouldDraw hook to just determine whether it should be drawn or not.